### PR TITLE
update random approach

### DIFF
--- a/ExBuddy/OrderBotTags/Gather/ExGatherTag.cs
+++ b/ExBuddy/OrderBotTags/Gather/ExGatherTag.cs
@@ -37,7 +37,7 @@
 	[LoggerName("ExGather")]
 	[XmlElement("ExGather")]
 	[XmlElement("GatherCollectable")]
-	public sealed class ExGatherTag : ExProfileBehavior
+	public class ExGatherTag : ExProfileBehavior
 	{
 		private static readonly object Lock = new object();
 

--- a/ExBuddy/OrderBotTags/Gather/GatherSpots/RandomApproachGatherSpot.cs
+++ b/ExBuddy/OrderBotTags/Gather/GatherSpots/RandomApproachGatherSpot.cs
@@ -41,7 +41,10 @@
 				result &= await tag.CastAura(Ability.Stealth);
 			}
 
-			return result;
+            //change the approach location for the next time we go to this node.
+		    approachLocation = HotSpots.Shuffle().First();
+
+            return result;
 		}
 
 		public override async Task<bool> MoveToSpot(ExGatherTag tag)
@@ -53,7 +56,8 @@
 				return false;
 			}
 
-			approachLocation = HotSpots.Shuffle().First();
+            if(approachLocation == null)
+			    approachLocation = HotSpots.Shuffle().First();
 
 			var result = await approachLocation.MoveToPointWithin(dismountAtDestination: Stealth);
 


### PR DESCRIPTION
update random approach so that we only change the target location AFTER we gather. (in case the bot tries to approach the same gather spot multiple times)

also, unseal the ExGatherTag  so that spearfishing (WIP) can be inherited from it. 