### PR TITLE
Swimming gathering fix

### DIFF
--- a/ExBuddy/Navigation/FlightEnabledNavigatorbeta.cs
+++ b/ExBuddy/Navigation/FlightEnabledNavigatorbeta.cs
@@ -83,12 +83,12 @@ namespace ExBuddy.Navigation
 
 		public double PathPrecisionSqr
 		{
-			get { return 4.0; }
+			get { return MovementManager.IsDiving ? 1.0 : 4.0; }
 		}
 
 		public double PathPrecision
 		{
-			get { return 2.0; }
+			get { return MovementManager.IsDiving ? 1.0 : 2.0; }
 		}
 
 		public bool VerboseLogging { get; set; }

--- a/ExBuddy/Navigation/FlightPath.cs
+++ b/ExBuddy/Navigation/FlightPath.cs
@@ -34,7 +34,7 @@ namespace ExBuddy.Navigation
 
 			Vector3 hit;
 			Vector3 distances;
-			var useStraight = !WorldManager.Raycast(Start, End, out hit, out distances);
+			var useStraight = MovementManager.IsDiving || !WorldManager.Raycast(Start, End, out hit, out distances);
 
 			for (var i = 0.0f + (1.0f / ((float)desiredNumberOfPoints)); i <= 1.0f; i += (1.0f / ((float)desiredNumberOfPoints)))
 			{


### PR DESCRIPTION
Modified "flight" navigator logic to better handle gathering while diving. 

* Arc navigation causes player character to dive into the floor indefinitely. Logic has been changed to force navigator to use a straight path when under water.
* Path precision value causes character to stop before getting in range of the gathering node. Logic has been changed to use 1.0 as both precision and sqr precision values.

(These changes could end up being undesirable, but they did fix the problem that I was having when attempting to create diving gathering profiles)