### PR TITLE
Initial Shadowbringers datatype fixes

### DIFF
--- a/ExBuddy/ExBuddy.csproj
+++ b/ExBuddy/ExBuddy.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Helpers\EorzeaTimeHelper.cs" />
     <Compile Include="Helpers\Lazier.cs" />
     <Compile Include="Helpers\CharacterResource.cs" />
+    <Compile Include="Helpers\CharacterResource_RBCN.cs" />
     <Compile Include="Helpers\ConditionTimer.cs" />
     <Compile Include="Helpers\NodeHelper.cs" />
     <Compile Include="Inventory\InventoryItem.cs" />

--- a/ExBuddy/Helpers/CharacterResource.cs
+++ b/ExBuddy/Helpers/CharacterResource.cs
@@ -6,7 +6,7 @@ using ff14bot.Objects;
 
 namespace ExBuddy.Helpers
 {
-    #if !RB_CN
+#if !RB_CN
     public static class CharacterResource
     {
         public static ushort GetGpPerTick()
@@ -48,5 +48,5 @@ namespace ExBuddy.Helpers
             get { return GameObjectManager.LocalPlayer; }
         }
     }
-    #endif
+#endif
 }

--- a/ExBuddy/Helpers/CharacterResource_RBCN.cs
+++ b/ExBuddy/Helpers/CharacterResource_RBCN.cs
@@ -6,36 +6,36 @@ using ff14bot.Objects;
 
 namespace ExBuddy.Helpers
 {
-    #if !RB_CN
+#if RB_CN
     public static class CharacterResource
     {
-        public static ushort GetGpPerTick()
+        public static short GetGpPerTick()
         {
             return (CharacterResource.Me.CurrentJob == ClassJobType.Miner && ConditionParser.IsQuestCompleted(68094))
                 || (CharacterResource.Me.CurrentJob == ClassJobType.Botanist && ConditionParser.IsQuestCompleted(68160))
                 || (CharacterResource.Me.CurrentJob == ClassJobType.Fisher && ConditionParser.IsQuestCompleted(68435))
-                ? (ushort) 6
-                : (ushort) 5;
+                ? (short) 6
+                : (short) 5;
         }
 
-        public static ushort GetEffectiveGp(int ticksTillGather)
+        public static short GetEffectiveGp(int ticksTillGather)
         {
             return GetEffectiveGp(ticksTillGather, GetGpPerTick());
         }
 
-        public static ushort GetEffectiveGp(int ticksTillGather, int gpPerTick)
+        public static short GetEffectiveGp(int ticksTillGather, int gpPerTick)
         {
             return ticksTillGather <= 0
                 ? CharacterResource.Me.CurrentGP
-                : (ushort) Math.Min(CharacterResource.Me.CurrentGP + (ticksTillGather * gpPerTick), CharacterResource.Me.MaxGP);
+                : (short) Math.Min(CharacterResource.Me.CurrentGP + (ticksTillGather * gpPerTick), CharacterResource.Me.MaxGP);
         }
 
-        public static TimeSpan EstimateExpectedRegenerationTime(ushort gpNeeded)
+        public static TimeSpan EstimateExpectedRegenerationTime(short gpNeeded)
         {
             return EstimateExpectedRegenerationTime(gpNeeded, CharacterResource.GetGpPerTick());
         }
 
-        public static TimeSpan EstimateExpectedRegenerationTime(ushort gpNeeded, ushort gpPerTick)
+        public static TimeSpan EstimateExpectedRegenerationTime(short gpNeeded, short gpPerTick)
         {
             var gpNeededTicks = gpNeeded / gpPerTick;
             var gpNeededSeconds = gpNeededTicks * 3;
@@ -48,5 +48,5 @@ namespace ExBuddy.Helpers
             get { return GameObjectManager.LocalPlayer; }
         }
     }
-    #endif
+#endif
 }

--- a/ExBuddy/OrderBotTags/Gather/Strategies/BeforeGatherGpRegenStrategy.cs
+++ b/ExBuddy/OrderBotTags/Gather/Strategies/BeforeGatherGpRegenStrategy.cs
@@ -42,11 +42,11 @@
 
         private readonly IBeforeGatherGpRegenStrategyLogger logger;
         private readonly CordialStockManager cordialStockManager;
-        #if RB_CN
+#if RB_CN
         protected readonly short gpPerTick;
-        #else
+#else
         protected readonly ushort gpPerTick;
-        #endif
+#endif
 
         protected IGatheringRotation gatherRotation;
         protected GatherStrategy gatherStrategy;

--- a/ExBuddy/OrderBotTags/Gather/Strategies/BeforeGatherGpRegenStrategy.cs
+++ b/ExBuddy/OrderBotTags/Gather/Strategies/BeforeGatherGpRegenStrategy.cs
@@ -42,7 +42,11 @@
 
         private readonly IBeforeGatherGpRegenStrategyLogger logger;
         private readonly CordialStockManager cordialStockManager;
+        #if RB_CN
         protected readonly short gpPerTick;
+        #else
+        protected readonly ushort gpPerTick;
+        #endif
 
         protected IGatheringRotation gatherRotation;
         protected GatherStrategy gatherStrategy;
@@ -187,7 +191,11 @@
             this.CalculateTargetAndCordialSelection();
 
             // Calculate regeneration parameters
+#if RB_CN
             this.RegeneratedGp = (short)(this.TargetGp - this.CordialGp - this.StartingGp);
+#else
+            this.RegeneratedGp = (ushort)(this.TargetGp - this.CordialGp - this.StartingGp);
+#endif
             if (this.RegeneratedGp < 0) this.RegeneratedGp = 0;
             this.EffectiveTimeToRegenerate = CharacterResource.EstimateExpectedRegenerationTime(this.RegeneratedGp);
         }
@@ -208,7 +216,11 @@
 
             foreach (var breakpointGp in this.gatherRotation.Attributes.RequiredGpBreakpoints.OrderByDescending(bp => bp))
             {
+#if RB_CN
                 this.TargetGp = this.BreakpointGp = (short)breakpointGp;
+#else
+                this.TargetGp = this.BreakpointGp = (ushort)breakpointGp;
+#endif
 
                 // If we'll regen enough, do not select a cordial
                 if (this.EffectiveGp >= this.TargetGp)
@@ -226,7 +238,11 @@
                     if (bestCordial != null)
                     {
                         this.Cordial = bestCordial;
+#if RB_CN
                         this.CordialGp = (short)CordialStockManager.CordialDataMap[bestCordial.ItemKey].Gp;
+#else
+                        this.CordialGp = (ushort)CordialStockManager.CordialDataMap[bestCordial.ItemKey].Gp;
+#endif
                         return;
                     }
                 }
@@ -236,7 +252,11 @@
             }
 
             // There is no way to regenerate the required GP
+#if RB_CN
             this.BreakpointGp = (short)lastBreakpointGpValue;
+#else
+            this.BreakpointGp = (ushort)lastBreakpointGpValue;
+#endif
             this.TargetGp = this.StartingGp;
         }
 
@@ -400,7 +420,11 @@
                     : string.Empty,
                 this.Cordial != null
                     ? this.CordialGp
+#if RB_CN
                     : (short)0
+#else
+                    : (ushort)0
+#endif
             );
         }
 
@@ -422,12 +446,24 @@
         /// <summary>
         /// Gets the player's starting GP at beginning of strategy
         /// </summary>
-        public short StartingGp { get; protected set; }
+#if RB_CN
+        public short StartingGp
+#else
+        public ushort StartingGp
+#endif
+        {
+            get;
+            protected set;
+        }
 
         /// <summary>
         /// Gets the player's current GP
         /// </summary>
+#if RB_CN
         public short CurrentGp
+#else
+        public ushort CurrentGp
+#endif
         {
             get { return ExProfileBehavior.Me.CurrentGP; }
         }
@@ -435,27 +471,67 @@
         /// <summary>
         /// Gets the player's max GP
         /// </summary>
-        public short MaxGp { get; protected set; }
+#if RB_CN
+        public short MaxGp
+#else
+        public ushort MaxGp
+#endif
+        {
+            get;
+            protected set;
+        }
 
         /// <summary>
         /// Gets what the player's GP will be when gathering begins
         /// </summary>
-        public short EffectiveGp { get; protected set; }
+#if RB_CN
+        public short EffectiveGp
+#else
+        public ushort EffectiveGp
+#endif
+        {
+            get;
+            protected set;
+        }
 
         /// <summary>
         /// Gets the gathering rotation breakpoint GP
         /// </summary>
-        public short BreakpointGp { get; protected set; }
+#if RB_CN
+        public short BreakpointGp
+#else
+        public ushort BreakpointGp
+#endif
+        {
+            get;
+            protected set;
+        }
 
         /// <summary>
         /// Gets the GP target to regenerate to
         /// </summary>
-        public short TargetGp { get; protected set; }
+#if RB_CN
+        public short TargetGp
+#else
+        public ushort TargetGp
+#endif
+        {
+            get;
+            protected set;
+        }
 
         /// <summary>
         /// Gets the GP that we will regenerate
         /// </summary>
-        public short RegeneratedGp { get; protected set; }
+#if RB_CN
+        public short RegeneratedGp
+#else
+        public ushort RegeneratedGp
+#endif
+        {
+            get;
+            protected set;
+        }
 
         /// <summary>
         /// Gets the cordial selected for use during regeneration
@@ -465,6 +541,14 @@
         /// <summary>
         /// Amount of GP provided by the cordial
         /// </summary>
-        public short CordialGp { get; protected set; }
+#if RB_CN
+        public short CordialGp
+#else
+        public ushort CordialGp
+#endif
+        {
+            get;
+            protected set;
+        }
     }
 }


### PR DESCRIPTION
Beginning with RebornBuddy 261 the datatypes for various character properties were changed from signed to unsigned numerics.

This commit cleans up the compiler problems caused by the datatype mismatches and keeps compatibility for the Chinese version, which still uses shorts for the properties.