### PR TITLE
fix to overflow exception thrown

### DIFF
--- a/ExBuddy/OrderBotTags/Gather/Strategies/BeforeGatherGpRegenStrategy.cs
+++ b/ExBuddy/OrderBotTags/Gather/Strategies/BeforeGatherGpRegenStrategy.cs
@@ -273,7 +273,7 @@
             }
 
             // Execute the wait coroutine
-            this.logger.RegeneratingGp(Convert.ToInt16((this.EffectiveTimeToRegenerate.TotalSeconds)));
+            this.logger.RegeneratingGp(Convert.ToInt32((this.EffectiveTimeToRegenerate.TotalSeconds)));
 
             await Coroutine.Wait(
                 this.EffectiveTimeTillGather,


### PR DESCRIPTION
not a very big change, but i didn't know whom to contact and where, so i might as well try through GH

[23:21:34.305 D] XXXXX.Coroutines.CoroutineUnhandledException: Exception was thrown by coroutine ---> System.OverflowException: Value was either too large or too small for an Int16.
 at System.Convert.ToInt16(Int32 value)
   at XXXXXX.OrderBotTags.Gather.Strategies.BeforeGatherGpRegenStrategy.<WaitForGpRegeneration>d__14.MoveNext() in XXXXXXXXXXXXXXXX\Plugins\ExBuddy\ExBuddy\OrderBotTags\Gather\Strategies\BeforeGatherGpRegenStrategy.cs:line 276

using .ToInt32 fixed it for me