### PR TITLE
OffsetManager memory leak fix and use current source file to find dat…

### DIFF
--- a/ExBuddy/Data/DataLocation.cs
+++ b/ExBuddy/Data/DataLocation.cs
@@ -1,0 +1,23 @@
+﻿namespace ExBuddy.Data
+{
+    using System.Diagnostics;
+    using System.IO;
+    using System.Runtime.CompilerServices;
+
+    public static class DataLocation
+    {
+        [System.Runtime.CompilerServices.MethodImpl(MethodImplOptions.NoInlining)]
+        public static DirectoryInfo SourceDirectory()
+        {
+            var frame = new StackFrame(0, true);
+            var file = frame.GetFileName();
+
+            if (!string.IsNullOrEmpty(file) && File.Exists(file))
+            {
+                return new DirectoryInfo(Path.GetDirectoryName(file));
+            }
+
+            return null;
+        }
+    }
+}

--- a/ExBuddy/Data/SqlData.cs
+++ b/ExBuddy/Data/SqlData.cs
@@ -25,7 +25,7 @@
 
         static SqlData()
         {
-            var path = Path.Combine(Environment.CurrentDirectory, "Plugins\\ExBuddy\\Data\\" + DbFileName);
+            var path = Path.Combine(DataLocation.SourceDirectory().FullName, DbFileName);
 
             if (File.Exists(path))
             {

--- a/ExBuddy/ExBuddy.csproj
+++ b/ExBuddy/ExBuddy.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\OffsetAttribute.cs" />
+    <Compile Include="Data\DataLocation.cs" />
     <Compile Include="Data\MasterpieceSupplyDutyResult.cs" />
     <Compile Include="Data\RequiredItemResult.cs" />
     <Compile Include="Data\SqlData.cs" />

--- a/ExBuddy/Plugins/Skywatcher/Providers/LocationProvider.cs
+++ b/ExBuddy/Plugins/Skywatcher/Providers/LocationProvider.cs
@@ -6,6 +6,7 @@
     using System;
     using System.IO;
     using System.Linq;
+    using Data;
 
     public class LocationProvider
     {
@@ -19,7 +20,7 @@
 
         static LocationProvider()
         {
-            var path = Path.Combine(Environment.CurrentDirectory, "Plugins\\ExBuddy\\Data\\" + LocationIndexFileName);
+            var path = Path.Combine(DataLocation.SourceDirectory().FullName, LocationIndexFileName);
 
             if (File.Exists(path))
             {

--- a/ExBuddy/Plugins/Skywatcher/Providers/WeatherRateProvider.cs
+++ b/ExBuddy/Plugins/Skywatcher/Providers/WeatherRateProvider.cs
@@ -6,6 +6,7 @@
     using System;
     using System.IO;
     using System.Linq;
+    using Data;
 
     internal class WeatherRateProvider
     {
@@ -19,7 +20,7 @@
 
         static WeatherRateProvider()
         {
-            var path = Path.Combine(Environment.CurrentDirectory, "Plugins\\ExBuddy\\Data\\" + WeatherRateIndexFileName);
+            var path = Path.Combine(DataLocation.SourceDirectory().FullName, WeatherRateIndexFileName);
 
             if (File.Exists(path))
             {

--- a/ExBuddy/Providers/MasterPieceSupplyDataProvider.cs
+++ b/ExBuddy/Providers/MasterPieceSupplyDataProvider.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Linq;
     using System.Xml.Linq;
+    using Data;
 
     public class MasterPieceSupplyDataProvider
     {
@@ -22,7 +23,7 @@
 
         static MasterPieceSupplyDataProvider()
         {
-            var path = Path.Combine(Environment.CurrentDirectory, "Plugins\\ExBuddy\\Data\\" + MsdFileName);
+            var path = Path.Combine(DataLocation.SourceDirectory().FullName, MsdFileName);
 
             if (File.Exists(path))
             {
@@ -31,7 +32,8 @@
             else
             {
                 DataFilePath =
-                    Directory.GetFiles(PluginManager.PluginDirectory, "*" + MsdFileName, SearchOption.AllDirectories).FirstOrDefault();
+                    Directory.GetFiles(PluginManager.PluginDirectory, "*" + MsdFileName, SearchOption.AllDirectories)
+                        .FirstOrDefault();
             }
 
             Instance = new MasterPieceSupplyDataProvider(DataFilePath);
@@ -62,7 +64,8 @@
             var result =
                 data.Root.Descendants("MS")
                     .FirstOrDefault(
-                        e => e.Elements().Any(c => string.Equals(c.Value, itemName, StringComparison.InvariantCultureIgnoreCase)));
+                        e => e.Elements().Any(c =>
+                            string.Equals(c.Value, itemName, StringComparison.InvariantCultureIgnoreCase)));
 
             if (result == null)
             {


### PR DESCRIPTION
OffsetManager memory leak fix and use current source file to find data file directory. 

The patternfinder needs to be used in a using statement and allocated outside of the for loop. This brings the memory usage down from 113mb to about 4mb. The data file change is just a trick using the debug info from stack trace to get the current source file location and using that to get the path to the data files so the path doesn't need to be hardcoded.